### PR TITLE
##-pf-feat-back-security-toggle V1.0

### DIFF
--- a/skillful_network_server/src/main/java/fr/uca/cdr/skillful_network/security/configuration/WebSecurity.java
+++ b/skillful_network_server/src/main/java/fr/uca/cdr/skillful_network/security/configuration/WebSecurity.java
@@ -3,6 +3,7 @@ package fr.uca.cdr.skillful_network.security.configuration;
 import fr.uca.cdr.skillful_network.security.filter.JWTAuthorizationFilter;
 import fr.uca.cdr.skillful_network.services.user.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -25,6 +26,18 @@ import static fr.uca.cdr.skillful_network.security.SecurityConstants.REGISTER_UR
 @EnableWebSecurity
 public class WebSecurity extends AbstractConfiguration {
 
+    // ###########################################################################
+    // WebSecurityConfigurerAdapter boolean for HTTP Pattern Matcher Security toggle
+    // to me be set in application.properties file :
+    // - security enabled (or empty/null/commented, default then):
+    // api.security.httpPatternMatcher.disabled=false
+    // - security disabled :
+    // api.security.httpPatternMatcher.disabled=true
+    // ###########################################################################
+
+    @Value("${api.security.httpPatternMatcher.disabled:false}")
+    private boolean httpPatternMatcherDisabled;
+
     @Autowired
     private UserService userService;
 
@@ -33,7 +46,10 @@ public class WebSecurity extends AbstractConfiguration {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.cors().and().csrf().disable().authorizeRequests()
+        http.cors().and().csrf().disable()
+                .authorizeRequests().antMatchers(HttpMethod.OPTIONS, "/**").permitAll();
+        if ( ! httpPatternMatcherDisabled) { // http pattern matcher enabled
+            http.authorizeRequests()
                 .antMatchers(HttpMethod.POST, REGISTER_URL, LOG_IN_URL, "/h2/**", "/whoami").permitAll()
                 .antMatchers(HttpMethod.GET, "/favicon.ico",
                         "/v2/api-docs",
@@ -42,8 +58,13 @@ public class WebSecurity extends AbstractConfiguration {
                         "/configuration/security",
                         "/swagger-ui.html",
                         "/webjars/**",
-                        "/h2/**").permitAll()
-                .anyRequest().authenticated()
+                        "/h2/**").permitAll().anyRequest().authenticated();
+        } else { // http pattern matcher disabled
+            http.authorizeRequests()
+                    .anyRequest().permitAll(); // toutes les pages/requêtes sont accessibles
+        }
+
+        http.authorizeRequests()
                 .and()
                 .addFilter(new JWTAuthorizationFilter(authenticationManager()))
                 // this disables session creation on Spring Security

--- a/skillful_network_server/src/main/java/fr/uca/cdr/skillful_network/security/configuration/WebSecurity.java
+++ b/skillful_network_server/src/main/java/fr/uca/cdr/skillful_network/security/configuration/WebSecurity.java
@@ -27,11 +27,11 @@ import static fr.uca.cdr.skillful_network.security.SecurityConstants.REGISTER_UR
 public class WebSecurity extends AbstractConfiguration {
 
     // ###########################################################################
-    // WebSecurityConfigurerAdapter boolean for HTTP Pattern Matcher Security toggle
-    // to me be set in application.properties file :
-    // - security enabled (or empty/null/commented, default then):
+    // WebSecurity boolean toggle for HTTP Pattern Matcher enablement.
+    // To be modified in application.properties file :
+    // - for security enabled (default or empty/null/commented):
     // api.security.httpPatternMatcher.disabled=false
-    // - security disabled :
+    // - for security disabled :
     // api.security.httpPatternMatcher.disabled=true
     // ###########################################################################
 

--- a/skillful_network_server/src/main/resources/application-dev.properties
+++ b/skillful_network_server/src/main/resources/application-dev.properties
@@ -11,3 +11,6 @@ spring.h2.console.path=/h2
 # logs configurations
 logging.level.fr.uca.cdr.skillful_network=TRACE
 logging.pattern.console=%clr([%-5level]) %clr(%d{yyyy-MM-dd HH:mm:ss}) %clr(%-40.40logger{39}) - %m%n
+
+# désactivation de la sécurité :
+api.security.httpPatternMatcher.disabled=true

--- a/skillful_network_server/src/main/resources/application-prod.properties
+++ b/skillful_network_server/src/main/resources/application-prod.properties
@@ -9,3 +9,6 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5Dialect
 logging.level.fr.uca.cdr.skillful_network=INFO
 logging.pattern.console=%clr([%-5level]) %clr(%d{yyyy-MM-dd HH:mm:ss}) %clr(%-40.40logger{39}) - %m%n
 
+
+# désactivation de la sécurité :
+#api.security.httpPatternMatcher.disabled=true

--- a/skillful_network_server/src/main/resources/application-test.properties
+++ b/skillful_network_server/src/main/resources/application-test.properties
@@ -11,3 +11,6 @@ spring.h2.console.path=/h2
 # logs configurations
 logging.level.fr.uca.cdr.skillful_network=TRACE
 logging.pattern.console=%clr([%-5level]) %clr(%d{yyyy-MM-dd HH:mm:ss}) %clr(%-40.40logger{39}) - %m%n
+
+# désactivation de la sécurité :
+#api.security.httpPatternMatcher.disabled=true


### PR DESCRIPTION
# OoS feature : web security toggle for http pattern matching enablement

###    To be modified in application.properties file :

- for enabled security (default or empty/null/commented):
api.security.httpPatternMatcher.disabled=false

- for disabled security :
api.security.httpPatternMatcher.disabled=true: